### PR TITLE
Use VirtualSpace instead of injecting spaces into new lines

### DIFF
--- a/CodeTextBox.cs
+++ b/CodeTextBox.cs
@@ -2804,6 +2804,11 @@ namespace PaintDotNet.Effects
                         this.Selections[0].AnchorVirtualSpace = indent;
                         this.ChooseCaretX();
                     }
+                    else
+                    {
+                        this.Selections[0].CaretVirtualSpace = 0;
+                        this.Selections[0].AnchorVirtualSpace = 0;
+                    }
                 }
             }
 

--- a/CodeTextBox.cs
+++ b/CodeTextBox.cs
@@ -50,6 +50,7 @@ namespace PaintDotNet.Effects
         private Theme theme;
         private const int Preprocessor = 64;
         private int indexForPurpleWords = -1;
+        private int previousLine = 0;
 
         private readonly ToolStrip lightBulbMenu = new ToolStrip();
         private readonly ScaledToolStripDropDownButton bulbIcon = new ScaledToolStripDropDownButton();
@@ -2772,6 +2773,39 @@ namespace PaintDotNet.Effects
                 }
             }
 
+            if (e.Change.HasFlag(UpdateChange.Selection))
+            {
+                if (this.CurrentLine != previousLine)
+                {
+                    previousLine = this.CurrentLine;
+
+                    int lineLength = this.Lines[this.CurrentLine].Text.TrimEnd(new char[] { '\r', '\n' }).Length;
+                    bool noSelection = this.SelectionStart == this.SelectionEnd;
+                    if (noSelection && lineLength == 0)
+                    {
+                        int indent = 0;
+                        int lineIndex = this.CurrentLine - 1;
+                        while (lineIndex >= 0)
+                        {
+                            string lineText = this.Lines[lineIndex].Text.Trim();
+                            if (lineText.Length > 0)
+                            {
+                                indent = lineText.EndsWith("{", StringComparison.Ordinal) ?
+                                    this.Lines[lineIndex].Indentation + this.TabWidth:
+                                    this.Lines[lineIndex].Indentation;
+
+                                break;
+                            }
+
+                            lineIndex--;
+                        }
+
+                        this.Selections[0].CaretVirtualSpace = indent;
+                        this.Selections[0].AnchorVirtualSpace = indent;
+                    }
+                }
+            }
+
             if (e.Change.HasFlag(UpdateChange.Selection) || e.Change.HasFlag(UpdateChange.Content))
             {
                 if (MapEnabled)
@@ -2826,23 +2860,6 @@ namespace PaintDotNet.Effects
                     }
                 }
             }
-        }
-
-        protected override void OnInsertCheck(InsertCheckEventArgs e)
-        {
-            if (e.Text.Equals("\r\n", StringComparison.Ordinal) ||
-                e.Text.Equals("\r", StringComparison.Ordinal) ||
-                e.Text.Equals("\n", StringComparison.Ordinal))
-            {
-                int line = this.LineFromPosition(e.Position);
-                e.Text += new string(' ', this.Lines[line].Indentation);
-                if (this.Lines[line].Text.Trim().EndsWith("{", StringComparison.Ordinal))
-                {
-                    e.Text += new string(' ', this.TabWidth);
-                }
-            }
-
-            base.OnInsertCheck(e);
         }
 
         protected override void OnCharAdded(CharAddedEventArgs e)
@@ -3061,6 +3078,16 @@ namespace PaintDotNet.Effects
             UpdateIndicatorBar();
 
             base.OnMarginClick(e);
+        }
+
+        protected override void OnMouseClick(MouseEventArgs e)
+        {
+            base.OnMouseClick(e);
+
+            if (this.Selections[0].AnchorVirtualSpace > 0)
+            {
+                this.Selections[0].CaretVirtualSpace = this.Selections[0].AnchorVirtualSpace;
+            }
         }
         #endregion
 

--- a/CodeTextBox.cs
+++ b/CodeTextBox.cs
@@ -2802,6 +2802,7 @@ namespace PaintDotNet.Effects
 
                         this.Selections[0].CaretVirtualSpace = indent;
                         this.Selections[0].AnchorVirtualSpace = indent;
+                        this.ChooseCaretX();
                     }
                 }
             }
@@ -3087,6 +3088,7 @@ namespace PaintDotNet.Effects
             if (this.Selections[0].AnchorVirtualSpace > 0)
             {
                 this.Selections[0].CaretVirtualSpace = this.Selections[0].AnchorVirtualSpace;
+                this.ChooseCaretX();
             }
         }
         #endregion


### PR DESCRIPTION
This will place the caret into "virtual space" when moving to an empty line.

To quote the Scintilla documentation:
> Virtual space is space beyond the end of each line. The caret may be moved into virtual space but no real space will be added to the document until there is some text typed or some other text insertion command is used. 

![virtualSpace](https://user-images.githubusercontent.com/11582193/55704934-0c3cf500-59cd-11e9-812b-42962bc8244f.png)


It should all work correctly, but please test in case I missed something.