### PR TITLE
Fix text color for color selection control

### DIFF
--- a/UIBuilder.cs
+++ b/UIBuilder.cs
@@ -807,13 +807,13 @@ namespace PaintDotNet.Effects
             {
                 if (colorName == "None" || colorName == "PrimaryColor" || colorName == "SecondaryColor")
                 {
-                    e.Graphics.DrawString(colorName, font, solidBrush, e.Bounds);
+                    e.Graphics.DrawString(colorName, font, SystemBrushes.ControlText, e.Bounds);
                 }
                 else
                 {
                     solidBrush.Color = Color.FromName(colorName);
                     e.Graphics.FillRectangle(solidBrush, new Rectangle(e.Bounds.X + 1, e.Bounds.Y + 1, e.Bounds.Height - 2, e.Bounds.Height - 2));
-                    e.Graphics.DrawString(colorName, font, solidBrush, new Rectangle(e.Bounds.X + e.Bounds.Height, e.Bounds.Y + 1, e.Bounds.Width - e.Bounds.Height, e.Bounds.Height));
+                    e.Graphics.DrawString(colorName, font, SystemBrushes.ControlText, new Rectangle(e.Bounds.X + e.Bounds.Height, e.Bounds.Y + 1, e.Bounds.Width - e.Bounds.Height, e.Bounds.Height));
                 }
             }
             e.DrawFocusRectangle();

--- a/UIBuilder.cs
+++ b/UIBuilder.cs
@@ -807,13 +807,14 @@ namespace PaintDotNet.Effects
             {
                 if (colorName == "None" || colorName == "PrimaryColor" || colorName == "SecondaryColor")
                 {
-                    e.Graphics.DrawString(colorName, font, SystemBrushes.ControlText, e.Bounds);
+                    e.Graphics.DrawString(Regex.Replace(colorName, "(\\B[A-Z])", " $1"), font, SystemBrushes.ControlText, e.Bounds);
                 }
                 else
                 {
                     solidBrush.Color = Color.FromName(colorName);
-                    e.Graphics.FillRectangle(solidBrush, new Rectangle(e.Bounds.X + 1, e.Bounds.Y + 1, e.Bounds.Height - 2, e.Bounds.Height - 2));
-                    e.Graphics.DrawString(colorName, font, SystemBrushes.ControlText, new Rectangle(e.Bounds.X + e.Bounds.Height, e.Bounds.Y + 1, e.Bounds.Width - e.Bounds.Height, e.Bounds.Height));
+                    e.Graphics.DrawRectangle(Pens.Black, new Rectangle(e.Bounds.X + 1, e.Bounds.Y + 1, e.Bounds.Height - 2, e.Bounds.Height - 2));
+                    e.Graphics.FillRectangle(solidBrush, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, e.Bounds.Height - 3, e.Bounds.Height - 3));
+                    e.Graphics.DrawString(Regex.Replace(colorName, "(\\B[A-Z])", " $1"), font, SystemBrushes.ControlText, new Rectangle(e.Bounds.X + e.Bounds.Height, e.Bounds.Y + 1, e.Bounds.Width - e.Bounds.Height, e.Bounds.Height));
                 }
             }
             e.DrawFocusRectangle();

--- a/UIBuilder.cs
+++ b/UIBuilder.cs
@@ -807,14 +807,14 @@ namespace PaintDotNet.Effects
             {
                 if (colorName == "None" || colorName == "PrimaryColor" || colorName == "SecondaryColor")
                 {
-                    e.Graphics.DrawString(Regex.Replace(colorName, "(\\B[A-Z])", " $1"), font, SystemBrushes.ControlText, e.Bounds);
+                    e.Graphics.DrawString(Regex.Replace(colorName, "(\\B[A-Z])", " $1"), font, solidBrush, e.Bounds);
                 }
                 else
                 {
+                    e.Graphics.DrawString(Regex.Replace(colorName, "(\\B[A-Z])", " $1"), font, solidBrush, new Rectangle(e.Bounds.X + e.Bounds.Height, e.Bounds.Y + 1, e.Bounds.Width - e.Bounds.Height, e.Bounds.Height));
                     solidBrush.Color = Color.FromName(colorName);
                     e.Graphics.DrawRectangle(Pens.Black, new Rectangle(e.Bounds.X + 1, e.Bounds.Y + 1, e.Bounds.Height - 2, e.Bounds.Height - 2));
                     e.Graphics.FillRectangle(solidBrush, new Rectangle(e.Bounds.X + 2, e.Bounds.Y + 2, e.Bounds.Height - 3, e.Bounds.Height - 3));
-                    e.Graphics.DrawString(Regex.Replace(colorName, "(\\B[A-Z])", " $1"), font, SystemBrushes.ControlText, new Rectangle(e.Bounds.X + e.Bounds.Height, e.Bounds.Y + 1, e.Bounds.Width - e.Bounds.Height, e.Bounds.Height));
                 }
             }
             e.DrawFocusRectangle();


### PR DESCRIPTION
Text for some colors are not clearly visible in Color Wheel control type's Default colors control.
![Untitled](https://user-images.githubusercontent.com/5532796/135764333-48694d99-163d-4d7c-aa11-e656f5865875.png)

Using my suggested fix, it displays like this:
![Untitled2](https://user-images.githubusercontent.com/5532796/135764374-f563b665-88b0-4ce2-a36e-fa0a86a40e0b.png)