### PR TITLE
Work around IServiceProvider getting disposed by child effect

### DIFF
--- a/CodeLab.cs
+++ b/CodeLab.cs
@@ -146,7 +146,7 @@ namespace PdnCodeLab
                     using IEffectEnvironment environment = this.renderingFlags.HasFlag(BitmapEffectRenderingFlags.ForceAliasedSelectionQuality)
                         ? this.Environment.CreateRef()
                         : this.Environment.CloneWithAliasedSelection();
-                    using (IEffect effect = userEffect.EffectInfo.CreateInstance(this.Services, environment))
+                    using (IEffect effect = userEffect.EffectInfo.CreateInstance(new ServiceProviderWrapper(this.Services), environment))
                     {
                         this.renderer = effect.CreateRenderer<IBitmapEffectRenderer>();
                     }

--- a/CodeLabConfigDialog.cs
+++ b/CodeLabConfigDialog.cs
@@ -401,7 +401,7 @@ namespace PdnCodeLab
             }
 
 #if !FASTDEBUG
-            using IEffect effect = ScriptBuilder.BuiltEffect.EffectInfo.CreateInstance(this.Services, this.Environment);
+            using IEffect effect = ScriptBuilder.BuiltEffect.EffectInfo.CreateInstance(new ServiceProviderWrapper(this.Services), this.Environment);
             using IEffectConfigForm previewDialog = effect.CreateConfigForm();
             {
                 previewToken = previewDialog.Token;

--- a/ServiceProviderWrapper.cs
+++ b/ServiceProviderWrapper.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace PdnCodeLab
+{
+    // This is for working around an issue in PDN 5.1 whereby the effect will dispose the
+    // IServiceProvider it was given when IEffectInfo2.CreateInstance() was called. This
+    // wrapper prevents that from happening. I (Rick) plan on fixing this for 5.1.1, but
+    // not yet sure when that will get released.
+    internal sealed class ServiceProviderWrapper
+        : IServiceProvider
+    {
+        private readonly IServiceProvider services;
+
+        public ServiceProviderWrapper(IServiceProvider services)
+        {
+            this.services = services;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return this.services.GetService(serviceType);
+        }
+    }
+}


### PR DESCRIPTION
As per discussion with BoltBait on Messenger last night

I haven't tested this yet though, but it should work. I'll also be fixing it in PDN for v5.1.1: https://github.com/paintdotnet/paint.net/issues/3793